### PR TITLE
(MERCURY-192) make openldap user generic

### DIFF
--- a/ansible/roles/openldap/openldapserver/tasks/generatesitedefault.yml
+++ b/ansible/roles/openldap/openldapserver/tasks/generatesitedefault.yml
@@ -4,8 +4,8 @@
   template:
     src: sitedefault.yml.j2
     dest: "./sitedefault.yml"
-    owner: "ec2-user"
-    group: "ec2-user"
+    owner: "{{ ansible_env.SUDO_USER }}"
+    group: "{{ ansible_env.SUDO_USER }}"
     mode: 0600
   delegate_to: 127.0.0.1
 


### PR DESCRIPTION
the user that persisted sitedefault.yml was hardcoded as ec2-user