### PR TITLE
(MERCURY-214) Reapply directory permissions after mount.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,23 +322,6 @@ ansible-playbook -v /sas/install/ansible/playbooks/prepare_nodes.yml \
           prepare_nodes/mount_cascache
     ```
 
- 1. __Download the VIRK predeployment playbook__
-
-    Make the [VIRK pre-install playbook](https://github.com/sassoftware/virk/tree/viya-3.4/playbooks/pre-install-playbook) available
-    
-    ```
-    Host Groups:
-       AnsibleController
-    Inputs: 
-       group_vars: 
-         VIRK_COMMIT_ID: 
-         VIRK_URL:
-         VIRK_DIR:
-       extra_vars: VIYA_VERSION
-    Role: prepare_nodes/get_virk
-    ```
-    
-
 #### IAAS specific setup steps:
 
 AWS:
@@ -554,6 +537,22 @@ Example invocation:
     
     ```
 
+ 1. __Download the VIRK predeployment playbook__
+
+    Make the [VIRK pre-install playbook](https://github.com/sassoftware/virk/tree/viya-3.4/playbooks/pre-install-playbook) available
+    
+    ```
+    Host Groups:
+       AnsibleController
+    Inputs: 
+       group_vars: 
+         VIRK_COMMIT_ID: 
+         VIRK_URL:
+         VIRK_DIR:
+       extra_vars: VIYA_VERSION
+    Role: prepare_nodes/get_virk
+    ```
+    
 
 ### Run VIRK 
     

--- a/ansible/roles/prepare_deployment/get_virk/tasks/main.yml
+++ b/ansible/roles/prepare_deployment/get_virk/tasks/main.yml
@@ -6,10 +6,12 @@
   - git
 
 - name: clone virk
+  vars:
+    VERSION: "{{ VIYA_VERSION }}"
   git:
     repo: "{{ VIRK_URL }}"
     dest: "{{ VIRK_DIR }}"
-    version: "{{VIRK_COMMIT_ID[VIYA_VERSION]}}"
+    version: "{{VIRK_COMMIT_ID[VERSION]}}"
     force: yes
 
 

--- a/ansible/roles/prepare_nodes/mount_disk/tasks/main.yml
+++ b/ansible/roles/prepare_nodes/mount_disk/tasks/main.yml
@@ -34,12 +34,19 @@
       dev: "{{ MOUNT_DISK }}"
 
 
-  - name: mount viya installation volume {{ MOUNT_DISK }} on {{ MOUNT_DIR }}
+  - name: mount volume {{ MOUNT_DISK }} on {{ MOUNT_DIR }}
     mount:
       name: "{{ MOUNT_DIR }}"
       src: "{{ MOUNT_DISK }}"
       fstype: xfs
       state: mounted
+      
+      
+  - name: reapply permissions for {{ MOUNT_DIR }} directory
+    file:
+      path: "{{ MOUNT_DIR }}"
+      mode: 0777
+      
 
   when: source_disk_stat.stat.exists == true
 


### PR DESCRIPTION
This fix changes directory permissions to 777 after the mount.  It applies to all mounted directories handled by the Quick Start.